### PR TITLE
Removed unnecessary dependencies from environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,10 +5,8 @@ channels:
 dependencies:
   - python=3.6
   - jupyter
-  - jupyter_contrib_nbextensions
   - lmfit
   - matplotlib
-  - mpld3
   - nb_conda_kernels
   - numpy
   - scipy  


### PR DESCRIPTION
I removed `mpld3` and `jupyter_contrib_nbextensions` from the `environment.yml`, created the RDC3 environment and ran the notebooks in that environment without problems. 

Here's my thinking:
* `mpld3` was not being used at all.
* `jupyter_contrib_nbextensions` adds a few nice features to Jupyter, like cell timings and ability to click a button to save a gist, but are relatively unstable, and not necessary either.
* `nb_conda_kernels` is not really necessary either, but it is nice for users to be able to select the RDC3 environment in the Jupyter Notebook, so I left that in. 